### PR TITLE
bug: Fix pandas missing module

### DIFF
--- a/training/conda_dependencies.yml
+++ b/training/conda_dependencies.yml
@@ -32,6 +32,9 @@ dependencies:
       # Training deps
       - scikit-learn
 
+      # Pandas
+      - pandas
+
       # Scoring deps
       - inference-schema[numpy-support]
 


### PR DESCRIPTION
In the CI pipeline, the module not found error was present as below.
![image](https://user-images.githubusercontent.com/54692758/160782915-2abcf234-62e9-4686-bf25-98fffc1d3aa9.png)

The issue was solved by adding pandas in conda dependencies of training folder. Pandas was only listed in the requirements.txt file installed with bash script. 